### PR TITLE
Add os_log instrumentation to 3DS v1 and 3DS v2 challenge flows

### DIFF
--- a/NISdk/Source/UI Components/ThreeDSTwoViewController.swift
+++ b/NISdk/Source/UI Components/ThreeDSTwoViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os.log
 import WebKit
 
 class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
@@ -16,7 +17,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
     }()
     private var hasInitialisedRequest: Bool = false
     private var fingerPrintCompleted: Bool = false
-    
+
     private var completionHandler: (Bool) -> Void
     private let activityIndicator = UIActivityIndicatorView(style: .medium)
     private var transactionService: TransactionService
@@ -24,14 +25,14 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
     private var paymentResponse: PaymentResponse
     private var frictionlessTimer: Timer?
     var paypageLink: String
-    
+
     private var authorizationLabel: UILabel {
         let authLabel = UILabel()
         authLabel.text = "Authenticating using 3DS".localized
         return authLabel
     }
     private let vStack = UIStackView()
-    
+
     init(with paymentResponse: PaymentResponse, accessToken: String,
          transactionService: TransactionServiceAdapter, completion: @escaping (Bool) -> Void) {
         self.completionHandler = completion
@@ -43,25 +44,25 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
         activityIndicator.hidesWhenStopped = true
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
+
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupVCSubviews()
         initWebView()
     }
-    
+
     private func setupVCSubviews() {
         vStack.addArrangedSubview(authorizationLabel)
         vStack.addArrangedSubview(activityIndicator)
         vStack.axis = .vertical
         vStack.spacing = 0
         vStack.alignment = .center
-        
+
         view.addSubview(vStack)
         vStack.anchor(top: nil,
                       leading: view.safeAreaLayoutGuide.leadingAnchor,
@@ -69,10 +70,10 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                       trailing: view.safeAreaLayoutGuide.trailingAnchor,
                       padding: .zero,
                       size: CGSize(width: 0, height: 100))
-        
+
         vStack.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         vStack.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-        
+
         view.backgroundColor = .white
         webView.navigationDelegate = self
         view.addSubview(webView)
@@ -80,10 +81,10 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                        leading: view.safeAreaLayoutGuide.leadingAnchor,
                        bottom: view.safeAreaLayoutGuide.bottomAnchor,
                        trailing: view.safeAreaLayoutGuide.trailingAnchor)
-        
+
         view.addSubview(vStack)
     }
-    
+
     private func showActivityIndicator() {
         DispatchQueue.main.async {
             UIView.animate(withDuration: 0.4,
@@ -91,7 +92,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                            completion: { _ in self.activityIndicator.startAnimating()})
         }
     }
-    
+
     private func hideActivityIndicator() {
         DispatchQueue.main.async {
             UIView.animate(withDuration: 0.4,
@@ -99,7 +100,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                            completion: { _ in self.activityIndicator.stopAnimating()})
         }
     }
-    
+
     private func initWebView() {
         if let threeDSServerTransID = paymentResponse.threeDSTwoConfig?.threeDSServerTransID,
            let threeDSMethodNotificationURL = paymentResponse.threeDSMethodNotificationURL,
@@ -109,6 +110,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
             // Adding this check to prevent multiple requests
             if(!hasInitialisedRequest) {
                 hasInitialisedRequest = true
+                os_log("[NISdk] 3DS v2 — fingerprint phase: loading method URL: %{public}@", log: NISdkLogger.payment, type: .info, threeDSMethodURL)
                 var request = URLRequest(url: url)
                 request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
                 request.httpMethod = "POST"
@@ -119,7 +121,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                 self.frictionlessTimer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: false) {
                     timer in
                     timer.invalidate()
-                    // frictionless has timedout. Proceed to Challenge
+                    os_log("[NISdk] 3DS v2 — fingerprint timed out (10s), proceeding with compInd=N", log: NISdkLogger.payment, type: .info)
                     self.webView.stopLoading()
                     self.webView.load(URLRequest(url: URL(string: "about:blank")!))
                     self.fingerPrintCompleted = true
@@ -128,17 +130,17 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                 RunLoop.current.add(self.frictionlessTimer!, forMode: .common)
             }
         } else {
-            // No method data and url found, continue to challenge
+            os_log("[NISdk] 3DS v2 — no method data/URL found, skipping fingerprint (compInd=U)", log: NISdkLogger.payment, type: .info)
             self.fingerPrintCompleted = true
             onCompleteFingerPrint(threeDSCompInd: "U")
         }
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.parent?.navigationController?.setNavigationBarHidden(true, animated: animated)
     }
-    
+
     // MARK: WKNavigationDelegate delegation methods
     // Gets called everytime the url is loaded
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -151,7 +153,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
             }
         }
     }
-    
+
     // Gets called after 3ds is performed and a 302 redirect is received from txn service
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
         if let url = webView.url?.absoluteString {
@@ -160,7 +162,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
             }
         }
     }
-    
+
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationResponse: WKNavigationResponse,
                  decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
@@ -230,28 +232,33 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
 
         decisionHandler(.allow, preferences)
     }
-    
+
     func handleThreeDSTwoStageCompletion() {
         if(!fingerPrintCompleted) {
+            os_log("[NISdk] 3DS v2 — fingerprint notification received, compInd=Y", log: NISdkLogger.payment, type: .info)
             fingerPrintCompleted = true
             onCompleteFingerPrint(threeDSCompInd: "Y")
         } else {
-            // Challenge is completed
+            os_log("[NISdk] 3DS v2 — challenge completed, posting challenge response", log: NISdkLogger.payment, type: .info)
             showActivityIndicator()
             guard let threeDSTwoChallengeResponseURL = paymentResponse.paymentLinks?.threeDSTwoChallengeResponseURL else {
+                os_log("[NISdk] 3DS v2 — missing challenge response URL, aborting", log: NISdkLogger.payment, type: .error)
                 self.completionHandler(true)
                 return
             }
             transactionService.postThreeDSTwoChallengeResponse(for: paymentResponse, using: threeDSTwoChallengeResponseURL) {
                 data, response, error in
+                os_log("[NISdk] 3DS v2 — challenge response posted", log: NISdkLogger.payment, type: .info)
                 self.completionHandler(false)
             }
         }
     }
-    
+
     func onCompleteFingerPrint(threeDSCompInd: String) {
+        os_log("[NISdk] 3DS v2 — onCompleteFingerPrint compInd=%{public}@", log: NISdkLogger.payment, type: .info, threeDSCompInd)
         self.frictionlessTimer?.invalidate()
         guard let authenticationsUrl = paymentResponse.paymentLinks?.threeDSTwoAuthenticationURL else {
+            os_log("[NISdk] 3DS v2 — missing authentication URL, aborting", log: NISdkLogger.payment, type: .error)
             self.completionHandler(true)
             return
         }
@@ -264,6 +271,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
         "browserUserAgent: window.navigator.userAgent"
         self.webView.evaluateJavaScript("(function(){ return ({ \(browserDataJS) }); })()") { (result, error) in
             guard let result = result else {
+                os_log("[NISdk] 3DS v2 — JS evaluation returned nil result, aborting", log: NISdkLogger.payment, type: .error)
                 self.completionHandler(true)
                 return
             }
@@ -273,7 +281,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                     let data = try JSONSerialization.data(withJSONObject: result, options: [])
                     browserInfo = try JSONDecoder().decode(BrowserInfo.self, from: data)
                 } catch {
-                    // Could not deserialise browser info
+                    os_log("[NISdk] 3DS v2 — failed to decode browser info: %{public}@", log: NISdkLogger.payment, type: .error, error.localizedDescription)
                     self.completionHandler(true)
                     return
                 }
@@ -281,12 +289,12 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                 _ = browserInfo?.with(browserJavascriptEnabled: true)
                 _ = browserInfo?.with(challengeWindowSize: "05")
                 guard let browserInfo = browserInfo else {
-                    // browser info null
+                    os_log("[NISdk] 3DS v2 — browser info is nil after decode, aborting", log: NISdkLogger.payment, type: .error)
                     self.completionHandler(true)
                     return
                 }
                 var notificationUrl = self.paymentResponse.threeDSMethodNotificationURL
-                
+
                 self.transactionService.getPayerIp(with: self.getIpUrl(
                     stringVal: self.paymentResponse.paymentLinks!.threeDSTwoAuthenticationURL!,
                     outletRef: self.paymentResponse.outletId!,
@@ -295,7 +303,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                     paypageLink: self.paypageLink),
                                                    using: self.accessToken,
                                                    on: { payerIPData, _, _ in
-                    
+
                     if (notificationUrl == nil) {
                         let authUrl = self.paymentResponse.paymentLinks!.threeDSTwoAuthenticationURL!
                         let notificationUrlPath = "/api/outlets/\(self.paymentResponse.outletId!)/orders/\(self.paymentResponse.orderReference!)" +
@@ -303,7 +311,7 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                         notificationUrl = self.getNotificationUrl(stringVal: authenticationsUrl, slug: notificationUrlPath, paymentLink: (self.paymentResponse.paymentLinks?.paymentLink)!)
                     }
                     guard let payerIPData = payerIPData else {
-                        // Unable to get IP address of payer
+                        os_log("[NISdk] 3DS v2 — failed to get payer IP address, aborting", log: NISdkLogger.payment, type: .error)
                         self.completionHandler(true)
                         return
                     }
@@ -312,15 +320,17 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                         let payerIpDict: [String: String] = try JSONDecoder().decode([String: String].self, from: payerIPData)
                         payerIp = payerIpDict["requesterIp"]
                     } catch {
-                        // Unable to get payer Ip address from decoded response
+                        os_log("[NISdk] 3DS v2 — failed to decode payer IP response: %{public}@", log: NISdkLogger.payment, type: .error, error.localizedDescription)
                         self.completionHandler(true)
                         return
                     }
                     guard let payerIp = payerIp else {
+                        os_log("[NISdk] 3DS v2 — requesterIp missing from payer IP response, aborting", log: NISdkLogger.payment, type: .error)
                         self.completionHandler(true)
                         return
                     }
-                    
+
+                    os_log("[NISdk] 3DS v2 — browser info collected, posting authentications (compInd=%{public}@)", log: NISdkLogger.payment, type: .info, threeDSCompInd)
                     let _ = browserInfo.with(browserIP: payerIp)
                     let threeDSAuthenticationsRequest = ThreeDSAuthenticationsRequest()
                         .with(threeDSCompInd: threeDSCompInd)
@@ -331,51 +341,54 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                         authenticationsUrl: authenticationsUrl)
                 })
             } else {
-                // Could not get browser info
+                os_log("[NISdk] 3DS v2 — JS evaluation error: %{public}@", log: NISdkLogger.payment, type: .error, error?.localizedDescription ?? "unknown")
                 self.completionHandler(true)
             }
         }
     }
-    
+
     func postAuthentications(threeDSAuthenticationsRequest: ThreeDSAuthenticationsRequest, authenticationsUrl: String) {
+        os_log("[NISdk] 3DS v2 — postAuthentications → %{public}@", log: NISdkLogger.payment, type: .info, authenticationsUrl)
         self.transactionService.postThreeDSAuthentications(
             for: self.paymentResponse,
             with: threeDSAuthenticationsRequest,
             using: authenticationsUrl,
             on: { authenticationsData, _, er in
-                // authentications done
                 guard let authenticationsData = authenticationsData else {
-                    // unable to parse data
+                    os_log("[NISdk] 3DS v2 — authentications response data is nil, aborting", log: NISdkLogger.payment, type: .error)
                     self.completionHandler(true)
                     return
                 }
-                
+
                 guard let threeDSTwoAuthenticationsResponse = try? JSONDecoder().decode(ThreeDSTwoAuthenticationsResponse.self, from: authenticationsData) else {
-                    // unable to decode threeDSTwoAuthenticationsResponse
+                    os_log("[NISdk] 3DS v2 — failed to decode authentications response, aborting", log: NISdkLogger.payment, type: .error)
                     self.completionHandler(true)
                     return
                 }
-                
+
+                os_log("[NISdk] 3DS v2 — authentications response state=%{public}@", log: NISdkLogger.payment, type: .info, threeDSTwoAuthenticationsResponse.state ?? "nil")
+
                 if(threeDSTwoAuthenticationsResponse.state == "FAILED") {
-                    // 3ds Failed something went wrong
+                    os_log("[NISdk] 3DS v2 — authentication state FAILED, aborting", log: NISdkLogger.payment, type: .error)
                     self.completionHandler(true)
                     return
-                    
                 }
-                
+
                 guard let transStatus = threeDSTwoAuthenticationsResponse.threeDSTwo?.transStatus else {
-                    // no transStatus found
+                    os_log("[NISdk] 3DS v2 — no transStatus in response, aborting", log: NISdkLogger.payment, type: .error)
                     self.completionHandler(true)
                     return
                 }
-                
+
+                os_log("[NISdk] 3DS v2 — transStatus=%{public}@", log: NISdkLogger.payment, type: .info, transStatus)
+
                 switch(transStatus) {
                 case "C":
-                    // Challenge flow
-                    // Open Challenge frame
+                    os_log("[NISdk] 3DS v2 — challenge flow: loading ACS challenge frame", log: NISdkLogger.payment, type: .info)
                     if let base64EncodedCReq = threeDSTwoAuthenticationsResponse.threeDSTwo?.base64EncodedCReq,
                        let acsUrlString = threeDSTwoAuthenticationsResponse.threeDSTwo?.acsURL,
                        let acsURL = URL(string: acsUrlString){
+                        os_log("[NISdk] 3DS v2 — posting creq to ACS URL: %{public}@", log: NISdkLogger.payment, type: .info, acsUrlString)
                         var request = URLRequest(url: acsURL)
                         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
                         request.httpMethod = "POST"
@@ -384,11 +397,12 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
                             self.webView.load(request)
                         }
                     } else {
-                        // Unable to obtain base64EncodedCReq and acsURL
+                        os_log("[NISdk] 3DS v2 — missing base64EncodedCReq or acsURL for challenge, aborting", log: NISdkLogger.payment, type: .error)
                         self.completionHandler(true)
                     }
                     break
                 default:
+                    os_log("[NISdk] 3DS v2 — frictionless flow (transStatus=%{public}@), completing", log: NISdkLogger.payment, type: .info, transStatus)
                     self.completionHandler(false)
                     break
                 }
@@ -425,4 +439,3 @@ extension ThreeDSTwoViewController {
         return "https://\(urlHost)\(slug)"
     }
 }
-

--- a/NISdk/Source/UI Components/ThreeDSTwoViewController.swift
+++ b/NISdk/Source/UI Components/ThreeDSTwoViewController.swift
@@ -412,18 +412,21 @@ class ThreeDSTwoViewController: UIViewController, WKNavigationDelegate {
 
 extension ThreeDSTwoViewController {
     private func getIpUrl(stringVal: String, outletRef: String, orderRef: String, paymentRef: String, paypageLink: String) -> String {
-        let urlHost = URL(string: paypageLink)?.host ?? ""
-        let slug =
-        "/api/outlets/\(outletRef)/orders/\(orderRef)/payments/\(paymentRef)/3ds2/requester-ip"
-        if (stringVal.localizedCaseInsensitiveContains("-uat") ||
-            stringVal.localizedCaseInsensitiveContains("sandbox")
-        ) {
-            return "https://\(urlHost)\(slug)"
-        }
-        if (stringVal.localizedCaseInsensitiveContains("-dev")) {
-            return "https://\(urlHost)\(slug)"
-        }
-        return "https://\(urlHost)\(slug)"
+        // The payment `_id` is returned as a URN (e.g. "urn:payment:<uuid>") in the saved-card /
+        // merchant-initiated 3DS2 flow. Left in place it produces an invalid request path
+        // (".../payments/urn:payment:<uuid>/3ds2/requester-ip"), so strip the prefix first.
+        let cleanPaymentRef = paymentRef.replacingOccurrences(of: "urn:payment:", with: "")
+
+        // `paypageLink` is absent in some saved-card / merchant-initiated order responses, which
+        // previously left an empty host ("https:///api/...") that fails with "Could not connect to
+        // the server". Fall back to deriving the paypage host from the authentication URL host.
+        let fallbackHost = URL(string: stringVal)?.host?.replacingOccurrences(of: "api-gateway", with: "paypage")
+        let urlHost = URL(string: paypageLink)?.host ?? fallbackHost ?? ""
+
+        let slug = "/api/outlets/\(outletRef)/orders/\(orderRef)/payments/\(cleanPaymentRef)/3ds2/requester-ip"
+        let ipUrl = "https://\(urlHost)\(slug)"
+        os_log("[NISdk] 3DS v2 — requester-ip URL resolved: %{public}@", log: NISdkLogger.payment, type: .info, ipUrl)
+        return ipUrl
     }
 
     private func getNotificationUrl(stringVal: String, slug: String, paymentLink: String) -> String {

--- a/NISdk/Source/UI Components/ThreeDSViewController.swift
+++ b/NISdk/Source/UI Components/ThreeDSViewController.swift
@@ -7,12 +7,13 @@
 //
 
 import Foundation
+import os.log
 import WebKit
 
 class ThreeDSViewController: UIViewController, WKNavigationDelegate {
     private var webView = WKWebView()
     private let activityIndicator = UIActivityIndicatorView(style: .medium)
-    
+
     private var acsUrl: String
     private var acsPaReq: String
     private var acsMd: String
@@ -20,8 +21,8 @@ class ThreeDSViewController: UIViewController, WKNavigationDelegate {
     private var completionHandler: (Bool) -> Void
     private var hasClosedWebView: Bool = false
     private var hasInitialisedRequest: Bool = false
-    
-    
+
+
     init(with acsUrl: String, acsPaReq: String, acsMd: String, threeDSTermURL: String, completion: @escaping (Bool) -> Void) {
         self.acsUrl = acsUrl
         self.acsPaReq = acsPaReq
@@ -32,19 +33,19 @@ class ThreeDSViewController: UIViewController, WKNavigationDelegate {
         activityIndicator.color = .white
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupSubviews()
     }
-    
+
     private func setupSubviews() {
         view.backgroundColor = .white
-        
+
         webView.alpha = 0
         webView.navigationDelegate = self
         view.addSubview(webView)
@@ -52,59 +53,66 @@ class ThreeDSViewController: UIViewController, WKNavigationDelegate {
                        leading: view.safeAreaLayoutGuide.leadingAnchor,
                        bottom: view.safeAreaLayoutGuide.bottomAnchor,
                        trailing: view.safeAreaLayoutGuide.trailingAnchor)
-        
+
         view.addSubview(activityIndicator)
         activityIndicator.alignCenterToCenterOf(parent: view)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         // Adding this check to prevent multiple requests
         if(!hasInitialisedRequest) {
             hasInitialisedRequest = true
+            os_log("[NISdk] 3DS v1 — loading ACS URL: %{public}@", log: NISdkLogger.payment, type: .info, acsUrl)
             var request = URLRequest(url: URL(string: acsUrl)!)
             request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpMethod = "POST"
             request.httpBody   = "PaReq=\(acsPaReq.encodeAsURL())&TermUrl=\(threeDSTermURL.encodeAsURL())&MD=\(acsMd.encodeAsURL())".data(using: .utf8)
-            
+
             webView.load(request)
             showActivityIndicator()
         }
     }
-    
+
     private func showActivityIndicator() {
         self.activityIndicator.alpha = 1
         self.activityIndicator.startAnimating()
     }
-    
+
     private func hideActivityIndicator() {
         UIView.animate(withDuration: 0.4,
                        animations: { self.webView.alpha = 1; self.activityIndicator.alpha = 0 },
                        completion: { _ in self.activityIndicator.stopAnimating()})
     }
-    
+
     // MARK: WKNavigationDelegate delegation methods
     // Gets called once the 3ds page is loaded
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        os_log("[NISdk] 3DS v1 — ACS page loaded", log: NISdkLogger.payment, type: .debug)
         hideActivityIndicator()
     }
-    
+
     // Gets called after 3ds is performed and a 302 redirect is received from txn service
     func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
-        if (webView.url?.queryParameters?["3ds_status"]) != nil {
+        if let status = webView.url?.queryParameters?["3ds_status"] as? String {
+            os_log("[NISdk] 3DS v1 — challenge redirect received, 3ds_status: %{public}@", log: NISdkLogger.payment, type: .info, status)
+            hasClosedWebView = true
+            webView.stopLoading()
+            self.completionHandler(false)
+        } else if (webView.url?.queryParameters?["3ds_status"]) != nil {
             hasClosedWebView = true
             webView.stopLoading()
             self.completionHandler(false)
         }
     }
-    
+
     // Gets called when the 3ds page fails to load
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        // 3ds Failed due to some error
+        os_log("[NISdk] 3DS v1 — page load failed: %{public}@", log: NISdkLogger.payment, type: .error, error.localizedDescription)
         webView.stopLoading()
         if(!hasClosedWebView) {
-            hasClosedWebView = true;
+            hasClosedWebView = true
             self.completionHandler(false)
         }
     }

--- a/NISdk/Source/Utils/NISdkLogger.swift
+++ b/NISdk/Source/Utils/NISdkLogger.swift
@@ -1,0 +1,11 @@
+import os.log
+
+struct NISdkLogger {
+    private static let subsystem = "com.ni.NISdk"
+
+    static let sdk     = OSLog(subsystem: subsystem, category: "SDK")
+    static let network = OSLog(subsystem: subsystem, category: "Network")
+    static let payment = OSLog(subsystem: subsystem, category: "Payment")
+    static let auth    = OSLog(subsystem: subsystem, category: "Authorization")
+    static let aani    = OSLog(subsystem: subsystem, category: "Aani")
+}


### PR DESCRIPTION
## Summary
- Adds `NISdkLogger` with a shared subsystem `com.ni.NISdk` and per-area `OSLog` categories (SDK / Network / Payment / Authorization / Aani) so SDK logs can be filtered cleanly in Console.app and `log stream`.
- Instruments `ThreeDSViewController` (3DS v1) with logs for ACS URL load, page-load completion, server redirect with `3ds_status`, and provisional load failures.
- Instruments `ThreeDSTwoViewController` (3DS v2) across the full flow: fingerprint method-URL load, 10s frictionless timeout, missing method data, fingerprint notification, challenge completion, missing challenge response URL, `onCompleteFingerPrint` with `threeDSCompInd`, JS browser-info collection, payer-IP fetch/decode, `postAuthentications` request/response (state, transStatus), challenge frame posting, and frictionless completion.
- All logs use `%{public}@` formatting and the `[NISdk]` prefix; failure paths use `type: .error`.

## Test plan
- [ ] Run a 3DS v1 challenge flow and verify ACS URL + load/finish/failure logs appear under the `Payment` category in Console.app.
- [ ] Run a 3DS v2 frictionless flow and confirm fingerprint, authentications, and `transStatus` logs are emitted with no error-level entries.
- [ ] Run a 3DS v2 challenge flow and verify challenge frame post + creq logs, followed by challenge completion log.
- [ ] Force failure paths (bad notification URL, JS eval failure, missing payer IP) and confirm error-level logs surface with the underlying description.
- [ ] Filter Console.app by subsystem `com.ni.NISdk` and category `Payment` to confirm only SDK-emitted lines appear.