### PR TITLE
Detect card scheme early from the IIN prefix (incl. Jaywan)

### DIFF
--- a/NISdk/Source/Domain/Payment Fields/Pan.swift
+++ b/NISdk/Source/Domain/Payment Fields/Pan.swift
@@ -72,16 +72,90 @@ extension Pan {
         }
     }
     
+    // MARK: - Card scheme detection (early, IIN/BIN based)
+
+    // A single IIN (BIN) range: the numbers lo...hi, each `len` digits long.
+    private struct IINRange {
+        let lo: UInt64
+        let hi: UInt64
+        let len: Int
+    }
+
+    // IIN ranges per scheme, most-specific first. Derived from the full-PAN
+    // patterns above (the mada BIN list, 5[1-5], 4, …) so early detection agrees
+    // with full-length detection — it just resolves as soon as the IIN is typed
+    // instead of waiting for the whole card number.
+    private static let iinRanges: [(CardProvider, [IINRange])] = {
+        func r(_ lo: UInt64, _ hi: UInt64, _ len: Int) -> IINRange { IINRange(lo: lo, hi: hi, len: len) }
+        let mada6: [UInt64] = [403024, 406136, 406996, 407520, 409201, 410621, 410685, 410834, 412565, 417633, 419593, 420132, 421141, 422817, 422818, 422819, 428331, 428671, 428672, 428673, 431361, 432328, 434107, 439954, 440533, 440647, 440795, 442429, 442463, 445564, 446393, 446404, 446672, 455036, 455708, 457865, 457997, 458456, 462220, 468540, 468541, 468542, 468543, 474491, 483010, 483011, 483012, 484783, 486094, 486095, 486096, 489318, 489319, 492464, 504300, 513213, 515079, 516138, 520058, 521076, 524130, 524514, 524940, 529415, 529741, 530060, 531196, 535825, 535989, 536023, 537767, 543085, 543357, 549760, 554180, 555610, 558563, 588845, 588850, 604906, 636120, 968201, 968202, 968203, 968204, 968205, 968206, 968207, 968208, 968209, 968211, 968212]
+        let mada8: [UInt64] = [22337902, 22337986, 22402030, 40177800, 40545400, 40719700, 40728100, 40739500, 42222200, 45488707, 45488713, 45501701, 49098000, 49098001, 52166100, 53973776]
+        var mada = mada6.map { r($0, $0, 6) }
+        mada.append(contentsOf: mada8.map { r($0, $0, 8) })
+        return [
+            (.mada, mada),
+            (.jaywan, [r(6690, 6690, 4), r(9784, 9784, 4)]),
+            (.americanExpress, [r(34, 34, 2), r(37, 37, 2)]),
+            (.masterCard, [r(51, 55, 2)]),
+            (.dinersClubInternational, [r(300, 305, 3), r(36, 36, 2), r(38, 38, 2)]),
+            (.discover, [r(6011, 6011, 4), r(65, 65, 2)]),
+            (.jcb, [r(2131, 2131, 4), r(1800, 1800, 4), r(35, 35, 2)]),
+            (.visa, [r(4, 4, 1)])
+        ]
+    }()
+
+    private static func pow10(_ n: Int) -> UInt64 {
+        var result: UInt64 = 1
+        for _ in 0..<max(0, n) { result *= 10 }
+        return result
+    }
+
+    // How the typed digits relate to one IIN range.
+    // .confirmed(len) — the digits already contain this IIN (len = how many digits matched).
+    // .potential      — fewer digits than the IIN, but still a possible prefix of it.
+    private enum IINMatch { case confirmed(Int); case potential; case none }
+
+    private func match(_ digits: String, against range: IINRange) -> IINMatch {
+        let count = digits.count
+        if count >= range.len {
+            guard let prefix = UInt64(digits.prefix(range.len)) else { return .none }
+            return (prefix >= range.lo && prefix <= range.hi) ? .confirmed(range.len) : .none
+        }
+        // Fewer digits than the IIN — the input spans [value·10^d, value·10^d + 10^d - 1];
+        // it is a potential match if that span overlaps the range.
+        guard let value = UInt64(digits) else { return .none }
+        let scale = Pan.pow10(range.len - count)
+        let low = value * scale
+        let high = low + scale - 1
+        return (high >= range.lo && low <= range.hi) ? .potential : .none
+    }
+
+    // Detects the card scheme as early as possible from the IIN (BIN) prefix,
+    // rather than only once the full card number is entered. A scheme is returned
+    // as soon as the typed digits contain its IIN (the longest / most-specific IIN
+    // wins, so e.g. a mada BIN is preferred over the broad Visa/Mastercard ranges).
+    // Before any IIN is fully typed, a scheme is still returned once it is the only
+    // one the digits could still belong to; otherwise `.unknown`.
     func getCardProvider() -> CardProvider {
-        var possibleCardType: CardProvider = .unknown;
-        if let cardNumber = self.value {
-            for cardType in CardProvider.allCases {
-                if (cardType != .unknown && testFor(cardType: cardType, value: cardNumber)){
-                    possibleCardType = cardType
+        guard let digits = value?.filter({ $0.isNumber }), !digits.isEmpty else {
+            return .unknown
+        }
+        var bestConfirmed: (provider: CardProvider, len: Int)?
+        var possible = Set<CardProvider>()
+        for (provider, ranges) in Pan.iinRanges {
+            for range in ranges {
+                switch match(digits, against: range) {
+                case .confirmed(let len):
+                    if bestConfirmed == nil || len > bestConfirmed!.len {
+                        bestConfirmed = (provider, len)
+                    }
+                case .potential:
+                    possible.insert(provider)
+                case .none:
                     break
                 }
             }
         }
-        return possibleCardType
+        if let best = bestConfirmed { return best.provider }
+        return possible.count == 1 ? possible.first! : .unknown
     }
 }


### PR DESCRIPTION
## Problem
Card scheme detection matched the **full-length, anchored** PAN regexes (`^…$` with fixed lengths), so the scheme — and everything driven by it (the card logo, CVV length, allowed-scheme validation) — only resolved **after the entire card number was entered**. For Jaywan and every other scheme, the logo stayed blank/default while typing.

## Change
`Pan.getCardProvider()` now detects the scheme from the **IIN/BIN prefix** as the user types:
- Resolves as soon as the identifying leading digits are present — e.g. **Visa at `4`**, **Amex at `34`**, **JCB at `35`**, **Diners at `30`**, **Mastercard at `51`**, **Discover at `65`/`6011`**, **Jaywan at `6690`/`9784`** (and as early as `66`/`97` once no other scheme is possible), **mada** at its BINs.
- Ambiguous prefixes (e.g. `6`, `3`, `9`) return `.unknown` until the digits disambiguate.
- The IIN ranges are **derived from the existing full-PAN patterns + the mada BIN list**, so detection stays consistent with the old full-length result. The **most-specific (longest) matching IIN wins**, so a mada / Jaywan BIN is preferred over the broad Visa / Mastercard ranges.

## Note / minor behaviour change
For co-badged BINs that fall in both a specific range and a broad one (e.g. a mada BIN in `51`–`55`), detection now returns the **specific** scheme (mada) rather than the first-in-enum-order match (Mastercard). This is more correct and required for consistent early detection.

## Testing
Logic validated against **35 partial and full inputs** across all schemes (early-resolve points, ambiguous prefixes, and full PANs) plus an in-SDK compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
