### PR TITLE
Scope card detection to supported schemes; detect Jaywan from the 8th digit

### DIFF
--- a/NISdk/Source/Domain/Payment Fields/Pan.swift
+++ b/NISdk/Source/Domain/Payment Fields/Pan.swift
@@ -12,7 +12,13 @@ class Pan {
     var value: String? {
         didSet { notifyPanChange() }
     }
-    
+
+    // The schemes the outlet actually accepts (order.paymentMethods.card). When set,
+    // card detection is scoped to these — so a card whose BIN belongs to a scheme the
+    // outlet does not support is not shown (matches the Android CardDetector, which is
+    // constructed with the supported cards). nil means "detect across all schemes".
+    var allowedCardProviders: Set<CardProvider>? = nil
+
     var cardProvider: CardProvider {
         get { return getCardProvider() }
     }
@@ -142,6 +148,12 @@ extension Pan {
         var bestConfirmed: (provider: CardProvider, len: Int)?
         var possible = Set<CardProvider>()
         for (provider, ranges) in Pan.iinRanges {
+            // Scope detection to the schemes the outlet supports (when known), so an
+            // unsupported scheme's card is never surfaced.
+            if let allowed = allowedCardProviders, !allowed.contains(provider) { continue }
+            // Jaywan shares its short 6690/9784 prefix with a wider space; only
+            // commit to it once 8 digits are entered so it isn't shown prematurely.
+            if provider == .jaywan && digits.count < Pan.jaywanMinDigits { continue }
             for range in ranges {
                 switch match(digits, against: range) {
                 case .confirmed(let len):
@@ -158,4 +170,7 @@ extension Pan {
         if let best = bestConfirmed { return best.provider }
         return possible.count == 1 ? possible.first! : .unknown
     }
+
+    // Jaywan is only detected once this many digits have been entered.
+    private static let jaywanMinDigits = 8
 }

--- a/NISdk/Source/UI Components/CardPaymentViewController.swift
+++ b/NISdk/Source/UI Components/CardPaymentViewController.swift
@@ -117,6 +117,8 @@ class CardPaymentViewController: UIViewController {
         if let makePaymentCallback = makePaymentCallback, let orderAmount = order.amount {
             self.makePaymentCallback = makePaymentCallback
             self.allowedCardProviders = order.paymentMethods?.card
+            // Scope live card-scheme detection (logo) to the outlet's supported cards.
+            self.pan.allowedCardProviders = order.paymentMethods?.card.map { Set($0) }
             let payButtonTitle: String = if NISdk.sharedInstance.shouldShowOrderAmount {
                  String.localizedStringWithFormat("Pay Button Title".localized, orderAmount.getFormattedAmount())
             } else {


### PR DESCRIPTION
## Problem
Card-scheme detection matched across **all** schemes regardless of what the outlet accepts, so the card logo would show a scheme the outlet doesn't support (e.g. **Jaywan on a non-Jaywan outlet**). The submit-time check already blocks unsupported cards, but the **logo during typing** was misleading. (Android's `CardDetector(supportedCards)` is scoped correctly by construction — this brings iOS in line.)

Separately, Jaywan resolved from its short 4-digit prefix (`6690`/`9784`), showing it very early.

## Change
- **Scope detection to supported cards:** added `Pan.allowedCardProviders`; `getCardProvider()` skips any scheme not in that set. `CardPaymentViewController` wires it from `order.paymentMethods.card`. When unset, behaviour is unchanged (detect all).
- **Jaywan at the 8th digit:** Jaywan is only resolved once ≥ 8 digits are entered.

## Testing
Verified with 11 logic cases (supported/unsupported scoping, Jaywan gating at digits 4–8, other schemes unaffected) and an in-SDK compile.

Builds on #99 (early IIN detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
