### PR TITLE
Apple Pay smoother journey + card form UX + force light mode

### DIFF
--- a/NISdk/Resources/Localizations/ar.lproj/Localizable.strings
+++ b/NISdk/Resources/Localizations/ar.lproj/Localizable.strings
@@ -26,6 +26,8 @@
 "Invalid card holder name" = "اسم حامل البطاقة غير صحيح";
 "All fields are mandatory" = "كل الحقول مطلوبة";
 "Cancel" = "إلغاء";
+"Next" = "التالي";
+"Previous" = "السابق";
 "Authenticating Payment" = "التحقق من الدفع";
 "Authenticating using 3DS" = "التحقق من الدفع";
 "Cancel Payment Title" = "إلغاء الدفع";

--- a/NISdk/Resources/Localizations/en.lproj/Localizable.strings
+++ b/NISdk/Resources/Localizations/en.lproj/Localizable.strings
@@ -26,6 +26,8 @@
 "Invalid card holder name" = "Invalid card holder name";
 "All fields are mandatory" = "All fields are mandatory";
 "Cancel" = "Cancel";
+"Next" = "Next";
+"Previous" = "Previous";
 "Authenticating Payment" = "Authenticating Payment";
 "Authenticating using 3DS" = "Authenticating using 3DS";
 "Cancel Payment Title" = "Cancel Payment";

--- a/NISdk/Source/NISdk.swift
+++ b/NISdk/Source/NISdk.swift
@@ -89,6 +89,9 @@ private class NISdkBundleLocator {}
         paymentViewController.modalPresentationStyle = .overCurrentContext
         if #available(iOS 13.0, *) {
             paymentViewController.isModalInPresentation = true
+            // The SDK palette is designed for a light background (label/title colors are
+            // fixed dark), so pin the SDK UI to light regardless of the host app / device.
+            navController.overrideUserInterfaceStyle = .light
         }
         DispatchQueue.main.async {
             parentViewController.present(navController, animated: true)
@@ -111,6 +114,7 @@ private class NISdkBundleLocator {}
         paymentViewController.modalPresentationStyle = .overCurrentContext
         if #available(iOS 13.0, *) {
             paymentViewController.isModalInPresentation = true
+            navController.overrideUserInterfaceStyle = .light
         }
         DispatchQueue.main.async {
             parentViewController.present(navController, animated: true)
@@ -132,6 +136,7 @@ private class NISdkBundleLocator {}
         paymentViewController.modalPresentationStyle = .overCurrentContext
         if #available(iOS 13.0, *) {
             paymentViewController.isModalInPresentation = true
+            navController.overrideUserInterfaceStyle = .light
         }
         DispatchQueue.main.async {
             parentViewController.present(navController, animated: true)
@@ -154,6 +159,7 @@ private class NISdkBundleLocator {}
             paymentViewController.modalPresentationStyle = .overCurrentContext
             if #available(iOS 13.0, *) {
                 paymentViewController.isModalInPresentation = true
+                navController.overrideUserInterfaceStyle = .light
             }
             DispatchQueue.main.async {
                 parentViewController.present(navController, animated: true)
@@ -177,6 +183,7 @@ private class NISdkBundleLocator {}
         paymentViewController.modalPresentationStyle = .overCurrentContext
         if #available(iOS 13.0, *) {
             paymentViewController.isModalInPresentation = true
+            paymentViewController.overrideUserInterfaceStyle = .light
         }
         parentViewController.present(paymentViewController, animated: true)
     }
@@ -192,6 +199,7 @@ private class NISdkBundleLocator {}
         paymentViewController.modalPresentationStyle = .overCurrentContext
         if #available(iOS 13.0, *) {
             paymentViewController.isModalInPresentation = true
+            navController.overrideUserInterfaceStyle = .light
         }
         DispatchQueue.main.async {
             parentViewController.present(navController, animated: true)

--- a/NISdk/Source/UI Components/CardPaymentViewController.swift
+++ b/NISdk/Source/UI Components/CardPaymentViewController.swift
@@ -34,13 +34,14 @@ class CardPaymentViewController: UIViewController {
         payButton.titleLabel?.font = UIFont.systemFont(ofSize: 20, weight: .medium)
         payButton.setTitleColor(NISdk.sharedInstance.niSdkColors.payButtonTitleColorHighlighted, for: .highlighted)
         payButton.layer.cornerRadius = 5
-        payButton.setTitle("Processing Payment".localized, for: .disabled)
         return payButton
     }()
     var errorLabel: UILabel = {
         let errorLabel = UILabel()
         errorLabel.textColor = .red
         errorLabel.text = ""
+        errorLabel.numberOfLines = 0
+        errorLabel.textAlignment = .center
         return errorLabel
     }()
 
@@ -48,15 +49,25 @@ class CardPaymentViewController: UIViewController {
         didSet {
             if(self.paymentInProgress) {
                 self.loadingSpinner.startAnimating()
+                self.payButton.setTitle("Processing Payment".localized, for: .disabled)
                 self.payButton.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.7)
                 self.payButton.isEnabled = false
             } else {
                 self.loadingSpinner.stopAnimating()
                 self.payButton.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)
-                self.payButton.isEnabled = true
+                // Drop the "Processing Payment" disabled title so a form-incomplete
+                // disable falls back to the normal Pay title again.
+                self.payButton.setTitle(nil, for: .disabled)
+                self.updatePayButtonEnabledState()
             }
         }
     }
+
+    // Text fields in visual/tab order, wired to the keyboard accessory toolbar so the
+    // user can jump between fields and dismiss the keyboard (revealing the Pay button)
+    // without it covering the button. The numeric keypads have no return key, so a
+    // toolbar is the only way to offer Next/Done for these fields.
+    private var orderedTextFields: [UITextField] = []
 
     let cardPreviewContainer = UIView()
     let loadingSpinner: UIActivityIndicatorView = {
@@ -118,6 +129,8 @@ class CardPaymentViewController: UIViewController {
         if let makePaymentCallback = makePaymentCallback, let orderAmount = order.amount {
             self.makePaymentCallback = makePaymentCallback
             self.allowedCardProviders = order.paymentMethods?.card
+            // Scope live card-scheme detection (logo) to the outlet's supported cards.
+            self.pan.allowedCardProviders = order.paymentMethods?.card.map { Set($0) }
             let payButtonTitle: String = if NISdk.sharedInstance.shouldShowOrderAmount {
                  String.localizedStringWithFormat("Pay Button Title".localized, orderAmount.getFormattedAmount())
             } else {
@@ -138,6 +151,8 @@ class CardPaymentViewController: UIViewController {
         setupCardPreviewComponent()
         setupCardInputForm()
         setupCancelButton()
+        // Start disabled — the Pay button only enables once every field is valid.
+        updatePayButtonEnabledState()
         NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
@@ -267,6 +282,14 @@ class CardPaymentViewController: UIViewController {
         add(nameInputVC, inside: nameContainer)
         nameInputVC.didMove(toParent: self)
 
+        // Field order used by the keyboard's Previous/Next/Done toolbar.
+        orderedTextFields = [panInputVC.panTextField,
+                             expiryInputVC.monthTextField,
+                             expiryInputVC.yearTextField,
+                             cvvInputVC.cvvTextField,
+                             nameInputVC.nameTextField]
+        setupKeyboardToolbars()
+
         let errorContainer = UIView()
         contentView.addSubview(errorContainer)
         errorContainer.anchor(top: vStack.bottomAnchor,
@@ -299,22 +322,118 @@ class CardPaymentViewController: UIViewController {
 
     @objc lazy private var onChangePan: onChangeTextClosure = { [weak self] textField in
         self?.pan.value = textField.text ?? ""
+        self?.updatePayButtonEnabledState()
     }
 
     @objc lazy private var onChangeMonth: onChangeTextClosure = { [weak self] textField in
         self?.expiryDate.month = textField.text ?? ""
+        self?.updatePayButtonEnabledState()
     }
 
     @objc lazy private var onChangeYear: onChangeTextClosure = { [weak self] textField in
         self?.expiryDate.year = textField.text ?? ""
+        self?.updatePayButtonEnabledState()
     }
 
     @objc lazy private var onChangeCVV: onChangeTextClosure = { [weak self] textField in
         self?.cvv.value = textField.text ?? ""
+        self?.updatePayButtonEnabledState()
     }
 
     @objc lazy private var onChangeName: onChangeTextClosure = { [weak self] textField in
         self?.cardHolderName.value = textField.text ?? ""
+        self?.updatePayButtonEnabledState()
+    }
+
+    // Enables the Pay button only when every card field is valid, and surfaces the
+    // relevant validation error(s) inline. Skipped while a payment is in flight so it
+    // doesn't fight the paymentInProgress disabled state.
+    private func updatePayButtonEnabledState() {
+        if paymentInProgress { return }
+        let isFormValid = validateAllFields().0
+        payButton.isEnabled = isFormValid
+        payButton.alpha = isFormValid ? 1.0 : 0.5
+        updateValidationErrorLabel()
+    }
+
+    // Builds a Previous / Next / Done toolbar above the keyboard for every input field.
+    // Previous is disabled on the first field, Next on the last, and Done always
+    // dismisses the keyboard so the Pay button underneath becomes tappable.
+    private func setupKeyboardToolbars() {
+        for (index, textField) in orderedTextFields.enumerated() {
+            let toolbar = UIToolbar()
+            toolbar.sizeToFit()
+
+            let previous = UIBarButtonItem(title: "Previous".localized, style: .plain,
+                                           target: self, action: #selector(focusPreviousField))
+            previous.isEnabled = index > 0
+
+            let next = UIBarButtonItem(title: "Next".localized, style: .plain,
+                                       target: self, action: #selector(focusNextField))
+            next.isEnabled = index < orderedTextFields.count - 1
+
+            let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace,
+                                                target: nil, action: nil)
+            let done = UIBarButtonItem(barButtonSystemItem: .done,
+                                       target: self, action: #selector(dismissKeyboard))
+
+            toolbar.items = [previous, next, flexibleSpace, done]
+            textField.inputAccessoryView = toolbar
+        }
+    }
+
+    private func currentFieldIndex() -> Int? {
+        return orderedTextFields.firstIndex(where: { $0.isFirstResponder })
+    }
+
+    @objc private func focusNextField() {
+        guard let index = currentFieldIndex(), index + 1 < orderedTextFields.count else {
+            dismissKeyboard()
+            return
+        }
+        orderedTextFields[index + 1].becomeFirstResponder()
+    }
+
+    @objc private func focusPreviousField() {
+        guard let index = currentFieldIndex(), index > 0 else { return }
+        orderedTextFields[index - 1].becomeFirstResponder()
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    // Shows a validation message for any field the user has started filling but left
+    // invalid (e.g. "Invalid expiry date"). Untouched/empty fields are left silent so
+    // a pristine form shows no errors.
+    private func updateValidationErrorLabel() {
+        var messages: [String] = []
+
+        if let panValue = pan.value, !panValue.isEmpty {
+            if !pan.validate() {
+                messages.append("Invalid pan number".localized)
+            } else if let allowedCardProviders = allowedCardProviders {
+                let panProvider = pan.getCardProvider()
+                if panProvider != .unknown && !Set(allowedCardProviders).contains(panProvider) {
+                    messages.append("Invalid card provider".localized)
+                }
+            }
+        }
+
+        let expiryTouched = !(expiryDate.month ?? "").isEmpty || !(expiryDate.year ?? "").isEmpty
+        if expiryTouched && !expiryDate.validate() {
+            messages.append("Invalid expiry date".localized)
+        }
+
+        if let cvvValue = cvv.value, !cvvValue.isEmpty, !cvv.validate() {
+            messages.append("Invalid CVV Field".localized)
+        }
+
+        if let nameValue = cardHolderName.value, !nameValue.isEmpty, !cardHolderName.validate() {
+            messages.append("Invalid card holder name".localized)
+        }
+
+        errorLabel.text = messages.joined(separator: "\n")
     }
 
     func validateAllFields() -> (Bool, [String:String]) {

--- a/NISdk/Source/UI Components/PaymentViewController.swift
+++ b/NISdk/Source/UI Components/PaymentViewController.swift
@@ -31,6 +31,23 @@ class PaymentViewController: UIViewController {
     private let cvv: String?
     private var host: String?
 
+    // Apple Pay concurrent-authorization coordination. For Apple Pay we present the
+    // native sheet immediately and run the authorization network call in parallel (no
+    // intermediate "Authenticating Payment" screen). The access token is only needed
+    // once the user authorizes, so this tracks whether that call has resolved and holds
+    // a waiter until it does.
+    private enum ApplePayAuthState { case pending, success, failed }
+    private var applePayAuthState: ApplePayAuthState = .pending
+    private var onApplePayAuthResolved: ((Bool) -> Void)?
+    // The Apple Pay sheet must be presented only once this controller is actually in the
+    // window (viewDidAppear) — presenting from viewDidLoad is dropped by UIKit. Set in
+    // viewDidLoad, consumed on first appearance.
+    private var pendingApplePaySheetPresentation = false
+    // Max time to wait for the background authorization token AFTER the user authorizes
+    // the Apple Pay sheet, before failing the sheet rather than hanging on the much
+    // longer default URLSession timeout.
+    private let applePayAuthTimeout: TimeInterval = 15
+
     init(order: OrderResponse, cardPaymentDelegate: CardPaymentDelegate,
          applePayDelegate: ApplePayDelegate?, paymentMedium: PaymentMedium) {
         self.order = order
@@ -79,6 +96,16 @@ class PaymentViewController: UIViewController {
         self.performPreAuthChecksAndBeginAuth()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Present the Apple Pay sheet now that we're in the window. Guarded so it only
+        // fires on the first appearance, not when the sheet later dismisses back to us.
+        if pendingApplePaySheetPresentation {
+            pendingApplePaySheetPresentation = false
+            initiatePaymentForm()
+        }
+    }
+
     // Perform any checks that need to be done before auth
     private func performPreAuthChecksAndBeginAuth() {
         if(self.paymentMedium == .ThreeDSTwo ) {
@@ -108,9 +135,20 @@ class PaymentViewController: UIViewController {
             return
         }
 
-        // Apple pay is not enabled by merchant, hence abort payment flow
-        if(self.paymentMedium == .ApplePay && (self.order.embeddedData?.payment?[0].paymentLinks?.applePayLink) == nil) {
-            self.finishPaymentAndClosePaymentViewController(with: .PaymentFailed, and: .ThreeDSFailed, and: .AuthFailed);
+        if(self.paymentMedium == .ApplePay) {
+            // Apple pay is not enabled by merchant, hence abort payment flow
+            if (self.order.embeddedData?.payment?[0].paymentLinks?.applePayLink) == nil {
+                self.finishPaymentAndClosePaymentViewController(with: .PaymentFailed, and: .ThreeDSFailed, and: .AuthFailed);
+                return
+            }
+            // Smoother journey: authorize in the background now, and present the Apple Pay
+            // sheet as soon as this controller appears (viewDidAppear) — no blocking
+            // "Authenticating Payment" screen. The token is only consumed after the user
+            // authorizes (Face/Touch ID), by which time the auth call has almost always
+            // completed. The sheet is presented on appear (not here) because presenting
+            // from viewDidLoad — before the view is in the window — is silently dropped.
+            self.beginConcurrentApplePayAuthorization()
+            self.pendingApplePaySheetPresentation = true
             return
         }
         // 1. Perform authorization by aquiring a payment token
@@ -168,6 +206,74 @@ class PaymentViewController: UIViewController {
             os_log("[NISdk] authorizePayment — failed: missing authCode or payment link", log: NISdkLogger.auth, type: .error)
             // Close payment view controller if authCode or payment link is broken
             self.finishPaymentAndClosePaymentViewController(with: .PaymentFailed, and: nil, and: .AuthFailed)
+        }
+    }
+
+    // Runs the authorization network call for Apple Pay WITHOUT showing the
+    // "Authenticating Payment" screen. Tokens are stored on success and any waiter
+    // registered via whenApplePayAuthResolved(_:) is notified.
+    private func beginConcurrentApplePayAuthorization() {
+        os_log("[NISdk] applePay — starting concurrent authorization (no loading screen)", log: NISdkLogger.auth, type: .info)
+        cardPaymentDelegate?.authorizationDidBegin?()
+        guard let authCode = order.getAuthCode(),
+              let paymentLink = order.orderLinks?.paymentAuthorizationLink else {
+            os_log("[NISdk] applePay — authorization failed: missing authCode or payment link", log: NISdkLogger.auth, type: .error)
+            self.resolveApplePayAuth(success: false)
+            return
+        }
+        transactionService.authorizePayment(for: authCode, using: paymentLink, on: {
+            [weak self] tokens in
+            guard let self = self else { return }
+            if let paymentToken = tokens["payment-token"], let accessToken = tokens["access-token"] {
+                self.paymentToken = paymentToken
+                self.accessToken = accessToken
+                os_log("[NISdk] applePay — concurrent authorization succeeded", log: NISdkLogger.auth, type: .info)
+                DispatchQueue.main.async {
+                    self.cardPaymentDelegate?.authorizationDidComplete?(with: .AuthSuccess)
+                    self.cardPaymentDelegate?.paymentDidBegin?()
+                    self.resolveApplePayAuth(success: true)
+                }
+            } else {
+                os_log("[NISdk] applePay — concurrent authorization failed: no tokens", log: NISdkLogger.auth, type: .error)
+                DispatchQueue.main.async {
+                    self.resolveApplePayAuth(success: false)
+                }
+            }
+        })
+    }
+
+    private func resolveApplePayAuth(success: Bool) {
+        applePayAuthState = success ? .success : .failed
+        let waiter = onApplePayAuthResolved
+        onApplePayAuthResolved = nil
+        waiter?(success)
+    }
+
+    // Invokes `completion` once authorization has resolved: immediately if it already
+    // has, otherwise when it does — or `false` if it hasn't within `applePayAuthTimeout`.
+    // `true` means the access token is available. The completion is guaranteed to run
+    // exactly once (resolution or timeout, whichever comes first).
+    private func whenApplePayAuthResolved(_ completion: @escaping (Bool) -> Void) {
+        var hasFired = false
+        let fireOnce: (Bool) -> Void = { success in
+            if hasFired { return }
+            hasFired = true
+            completion(success)
+        }
+        switch applePayAuthState {
+        case .success:
+            fireOnce(true)
+        case .failed:
+            fireOnce(false)
+        case .pending:
+            onApplePayAuthResolved = fireOnce
+            let timeout = applePayAuthTimeout
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+                guard !hasFired else { return }
+                os_log("[NISdk] applePay — token not received within %.0fs of authorization, failing sheet", log: NISdkLogger.auth, type: .error, timeout)
+                self?.onApplePayAuthResolved = nil
+                fireOnce(false)
+            }
         }
     }
 
@@ -242,29 +348,45 @@ class PaymentViewController: UIViewController {
 
     lazy private var handleApplePayAuthorization: OnAuthorizeApplePayCallback  = {
         [unowned self] payment, completion in
-        self.getPayerIp() { (payerIp) -> () in
-            if let payment = payment, let completion = completion {
-                self.transactionService.postApplePayResponse(for: self.order,
-                                                             with: payment,
-                                                             using: self.accessToken!,
-                                                             payerIp: payerIp, on: {
-                    [unowned self] data, response, error in
-                    if let data = data {
-                        do {
-                            let paymentResponse: PaymentResponse = try JSONDecoder().decode(PaymentResponse.self, from: data)
-                            if(paymentResponse.state == "AUTHORISED" || paymentResponse.state == "CAPTURED" || paymentResponse.state == "PURCHASED" || paymentResponse.state == "VERIFIED" || paymentResponse.state == "POST_AUTH_REVIEW") {
-                                completion(PKPaymentAuthorizationResult(status: .success, errors: nil), paymentResponse)
-                            } else {
-                                completion(PKPaymentAuthorizationResult(status: .failure, errors: nil), paymentResponse)
+        // The Apple Pay sheet was presented without waiting for authorization. Now that
+        // the user has authorized, ensure the access token has arrived (it almost always
+        // has, during the Face/Touch ID step) before posting the Apple Pay response.
+        self.whenApplePayAuthResolved { authSucceeded in
+            guard authSucceeded, let accessToken = self.accessToken else {
+                // Authorization failed or its token never arrived — fail the Apple Pay
+                // sheet gracefully rather than crashing on a missing token.
+                os_log("[NISdk] applePay — authorization unavailable at authorize time, failing sheet", log: NISdkLogger.payment, type: .error)
+                if let completion = completion {
+                    completion(PKPaymentAuthorizationResult(status: .failure, errors: nil), nil)
+                } else {
+                    self.handlePaymentResponse(nil)
+                }
+                return
+            }
+            self.getPayerIp() { (payerIp) -> () in
+                if let payment = payment, let completion = completion {
+                    self.transactionService.postApplePayResponse(for: self.order,
+                                                                 with: payment,
+                                                                 using: accessToken,
+                                                                 payerIp: payerIp, on: {
+                        [unowned self] data, response, error in
+                        if let data = data {
+                            do {
+                                let paymentResponse: PaymentResponse = try JSONDecoder().decode(PaymentResponse.self, from: data)
+                                if(paymentResponse.state == "AUTHORISED" || paymentResponse.state == "CAPTURED" || paymentResponse.state == "PURCHASED" || paymentResponse.state == "VERIFIED" || paymentResponse.state == "POST_AUTH_REVIEW") {
+                                    completion(PKPaymentAuthorizationResult(status: .success, errors: nil), paymentResponse)
+                                } else {
+                                    completion(PKPaymentAuthorizationResult(status: .failure, errors: nil), paymentResponse)
+                                }
+                            } catch let error {
+                                os_log("[NISdk] makeApplePayment — failed to decode payment response: %{public}@", log: NISdkLogger.payment, type: .error, error.localizedDescription)
+                                completion(PKPaymentAuthorizationResult(status: .failure, errors: nil), nil)
                             }
-                        } catch let error {
-                            os_log("[NISdk] makeApplePayment — failed to decode payment response: %{public}@", log: NISdkLogger.payment, type: .error, error.localizedDescription)
-                            completion(PKPaymentAuthorizationResult(status: .failure, errors: nil), nil)
                         }
-                    }
-                })
-            } else {
-                self.handlePaymentResponse(nil)
+                    })
+                } else {
+                    self.handlePaymentResponse(nil)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Three SDK-side improvements, all in native NISdk. No version bump, no podspec/Examples changes (kept as local-only).

### 1. Apple Pay — remove the intermediate "Authenticating Payment" screen (Kibsons UX request)
- Present the `PKPaymentAuthorizationViewController` immediately; run `authorizePayment` **concurrently** in the background instead of blocking behind the full-screen auth loader.
- The access token is only consumed **after** the user authorizes (Face/Touch ID), so it overlaps the sheet-review + biometric time.
- Sheet is presented from `viewDidAppear` (not `viewDidLoad`) — presenting before the controller is in the window is silently dropped by UIKit.
- `didAuthorizePayment` waits for the token with a **15s timeout**, exactly-once completion, and graceful failure. **Removes a `self.accessToken!` force-unwrap** that could crash if the user authorized before auth returned.

### 2. Card payment form UX
- Pay button disabled/dimmed until all fields are valid.
- Inline validation errors for touched-but-invalid fields.
- Previous/Next/Done keyboard accessory toolbar (numeric keypads have no return key) so the keyboard can be dismissed to reveal the Pay button.
- New `Next`/`Previous` localized strings (en, ar).

### 3. Force light mode for SDK-presented screens
- The palette's label/title colors are fixed dark → unreadable on a dynamic dark background. Pin the SDK's nav controllers / presented VCs to `.light`.

## Testing done
- ✅ Builds clean: NISdk framework + native `Simple Integration` (Demo App) + the RN `SimpleIntegration` app (via local `:path` pod).
- ✅ Apple Pay verified **in the simulator through the RN app** — sheet presents (no intermediate screen) and returns cleanly. Network logs confirm the concurrent `paymentAuthorization` call fires.

## ⚠️ Before merge / release — reviewer notes
- **Apple Pay not yet device-tested.** Full Face ID authorization + real token consumption (real merchant ID + Wallet) must be verified on a physical device. The concurrent-auth reordering means an auth **failure now surfaces after** the user engages the sheet (accepted trade-off) — please confirm this is acceptable.
- Consider whether the 4 concerns should be split into separate PRs; they share `NISdk.swift`, so they're grouped here.
- **RN delivery** requires a tagged NISdk release + bumping `react-native-ni-sdk.podspec`'s `NISdk` pin afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)